### PR TITLE
useOrgの作成(getAccesibleOrgs, getOrgInfo)

### DIFF
--- a/composables/useOrg.ts
+++ b/composables/useOrg.ts
@@ -1,0 +1,87 @@
+export type Form = {
+  id: string
+  name: string
+  summary: string
+  description: string
+  deadline: string
+  status: number
+  is_open: boolean
+}
+
+export type OrgInfo = {
+  org_id: string
+  org_name: string
+  event_id: string
+  event_name: string
+  forms: Form[] | null
+}
+
+export type AccessibleOrg = {
+  id: string
+  name: string
+  event_id: string
+  event_name: string
+  is_open: boolean
+}
+
+export const useOrg = () => {
+  const client = useApiClient()
+  const orgInfo: Ref<OrgInfo | null> = useState('org', () => null)
+  const accessibleOrgs: Ref<AccessibleOrg[] | null> = useState(
+    'accessibleOrgs',
+    () => null
+  )
+
+  const getAccessibleOrgs = async (): Promise<AccessibleOrg[] | null> => {
+    if (accessibleOrgs.value) {
+      return accessibleOrgs.value
+    }
+    const fetchedOrgs = await client
+      .get('/api/v1/orgs')
+      .then((resp) => {
+        if (resp.error) {
+          console.error('error fetching orgs\n', resp.error)
+          return null
+        }
+        if (resp && resp.data && resp.data.orgs) {
+          console.error('response is empty')
+          return null
+        }
+        return resp.data as { orgs: AccessibleOrg[] }
+      })
+      .catch((e) => {
+        console.error(e)
+        return null
+      })
+    accessibleOrgs.value =
+      fetchedOrgs && fetchedOrgs.orgs ? fetchedOrgs.orgs : null
+    return accessibleOrgs.value
+  }
+
+  const getOrgInfo = async (orgId: string): Promise<OrgInfo | null> => {
+    if (orgInfo.value) {
+      return orgInfo.value
+    }
+    const fetchedOrgInfo = await client
+      .get('/api/v1/orgs', { org_id: orgId })
+      .then((resp) => {
+        if (resp.error) {
+          console.error('error fetching orgInfo\n', resp.error)
+          return null
+        }
+        if (resp && resp.data && resp.data.orgs) {
+          console.error('response is empty')
+          return null
+        }
+        return resp.data as { orgs: OrgInfo }
+      })
+      .catch((e) => {
+        console.error(e)
+        return null
+      })
+    orgInfo.value =
+      fetchedOrgInfo && fetchedOrgInfo.orgs ? fetchedOrgInfo.orgs : null
+    return orgInfo.value
+  }
+  return { getAccessibleOrgs, getOrgInfo }
+}

--- a/composables/useOrg.ts
+++ b/composables/useOrg.ts
@@ -1,3 +1,4 @@
+import { useOrgIdStore } from '~/stores/orgId'
 export type Form = {
   id: string
   name: string
@@ -27,61 +28,102 @@ export type AccessibleOrg = {
 export const useOrg = () => {
   const client = useApiClient()
   const orgInfo: Ref<OrgInfo | null> = useState('org', () => null)
-  const accessibleOrgs: Ref<AccessibleOrg[] | null> = useState(
+  const accessibleOrgs: Ref<AccessibleOrg[]> = useState(
     'accessibleOrgs',
-    () => null
+    () => []
   )
 
-  const getAccessibleOrgs = async (): Promise<AccessibleOrg[] | null> => {
-    if (accessibleOrgs.value) {
+  /**
+   * アクセス可能な企画団体一覧を取得する関数
+   *
+   * @returns {Promise<AccessibleOrg[]>}
+   */
+  const getAccessibleOrgs = async (): Promise<AccessibleOrg[]> => {
+    if (accessibleOrgs.value && accessibleOrgs.value.length > 0) {
       return accessibleOrgs.value
     }
-    const fetchedOrgs = await client
+    const fetchedData = await client
       .get('/api/v1/orgs')
       .then((resp) => {
-        if (resp.error) {
-          console.error('error fetching orgs\n', resp.error)
-          return null
-        }
-        if (resp && resp.data && resp.data.orgs) {
-          console.error('response is empty')
-          return null
-        }
-        return resp.data as { orgs: AccessibleOrg[] }
+        return resp.data // Promiseオブジェクトから特定のプロパティ(orgs)を取得できないため
       })
       .catch((e) => {
-        console.error(e)
-        return null
+        throw new Error(e)
       })
-    accessibleOrgs.value =
-      fetchedOrgs && fetchedOrgs.orgs ? fetchedOrgs.orgs : null
+    accessibleOrgs.value = fetchedData.orgs
     return accessibleOrgs.value
   }
 
-  const getOrgInfo = async (orgId: string): Promise<OrgInfo | null> => {
+  /**
+   * アクセスできる企画団体の中から、現在操作対象となっている企画団体を取得する関数
+   *
+   * @returns {Promise<OrgInfo>}
+   */
+  const getCurrentOrg = async (): Promise<OrgInfo> => {
     if (orgInfo.value) {
       return orgInfo.value
     }
+    if (useOrgIdStore().getOrgId) {
+      orgInfo.value = await getOrgInfo(useOrgIdStore().getOrgId).catch((e) => {
+        throw new Error(e)
+      })
+      return orgInfo.value
+    }
+    if (accessibleOrgs.value.length > 0) {
+      useOrgIdStore().setOrgId(accessibleOrgs.value[0].id)
+      orgInfo.value = await getOrgInfo(accessibleOrgs.value[0].id).catch(
+        (e) => {
+          throw new Error(e)
+        }
+      )
+      return orgInfo.value
+    }
+    throw new Error('No OrgInfo and AccessibleOrgs')
+  }
+
+  /**
+   * 指定された orgId に該当する企画団体を操作対象の企画団体とする関数
+   *
+   * @param orgId
+   * @returns
+   */
+  const setCurrentOrg = async (orgId: string): Promise<void> => {
+    useOrgIdStore().setOrgId(orgId)
+    orgInfo.value = await getOrgInfo(orgId).catch((e) => {
+      throw new Error(e)
+    })
+  }
+
+  /* util 関数 ----------------------------------------------/
+
+
+  /**
+   * org_id から OrgInfo を取得する関数
+   *
+   * @param orgId
+   * @return {Promise<OrgInfo>}
+   */
+  const getOrgInfo = async (orgId: string): Promise<OrgInfo> => {
     const fetchedOrgInfo = await client
-      .get('/api/v1/orgs', { org_id: orgId })
+      .get('/api/v1/org', { org_id: orgId })
       .then((resp) => {
         if (resp.error) {
-          console.error('error fetching orgInfo\n', resp.error)
-          return null
+          throw new Error(resp.error)
         }
-        if (resp && resp.data && resp.data.orgs) {
-          console.error('response is empty')
-          return null
+        if (!resp || !resp.data) {
+          throw new Error('invalid response')
         }
-        return resp.data as { orgs: OrgInfo }
+        return resp.data as OrgInfo
       })
       .catch((e) => {
-        console.error(e)
-        return null
+        throw new Error(e)
       })
-    orgInfo.value =
-      fetchedOrgInfo && fetchedOrgInfo.orgs ? fetchedOrgInfo.orgs : null
-    return orgInfo.value
+    return fetchedOrgInfo
   }
-  return { getAccessibleOrgs, getOrgInfo }
+
+  return {
+    getAccessibleOrgs,
+    getCurrentOrg,
+    setCurrentOrg
+  }
 }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import AppSidebar from './AppSidebar.vue'
+import AppSidebar from '~/layouts/AppSidebar.vue'
 
 useHead({
   title: 'Top',
   titleTemplate: (title) => `${title} | YNU-fes`
 })
+const user = await useLogin().getCurrentUser()
 </script>
 <template>
   <div id="dashboard-root-frame">

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -73,7 +73,7 @@ export default defineNuxtConfig({
       baseURL: 'http://localhost:1306',
       callbackURL: 'http://localhost:1306/api/v1/auth/line/callback',
       lineClientID: process.env.LINE_CLIENT_ID,
-      enableRouting: false
+      enableRouting: true
     }
   }
 })

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,21 +1,30 @@
 <script lang="ts" setup>
-import { onBeforeMount, ref } from 'vue'
+import { useOrg, type AccessibleOrg } from '~/composables/useOrg'
 useHead({ title: 'top' })
 
-const showLogin = ref(false)
-const showOrgs = ref(false)
-onBeforeMount(() => {
-  console.log(document.cookie)
-})
+const accessibleOrgs: AccessibleOrg[] | null =
+  await useOrg().getAccessibleOrgs()
+const orgInfo: OrgInfo | null =
+  accessibleOrgs != null
+    ? await useOrg().getOrgInfo(accessibleOrgs[0].id)
+    : null
 </script>
 <template>
-  <main class="main-content-wrapper"></main>
+  <main class="main-content-wrapper">
+    <div v-if="!accessibleOrgs">
+      <p class="mx-auto w-fit mt-4 xl:ml-8">
+        アクセスできる企画団体が存在しません
+      </p>
+    </div>
+    <div v-else>
+      <pre class="util-color-bg-main w-fit p-5 mx-auto mt-4">{{
+        'アクセスできる企画団体一覧: ' +
+        JSON.stringify(accessibleOrgs, null, '\t')
+      }}</pre>
+      <pre class="util-color-bg-main w-fit p-5 mx-auto mt-4">{{
+        'デフォルトの企画団体情報: ' + JSON.stringify(orgInfo, null, '\t')
+      }}</pre>
+    </div>
+  </main>
 </template>
-<style>
-.main-content-wrapper {
-  margin: 20px 40px;
-}
-.count-down {
-  margin: 40px 0;
-}
-</style>
+<style></style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,17 +1,31 @@
 <script lang="ts" setup>
-import { useOrg, type AccessibleOrg } from '~/composables/useOrg'
+import { useOrg } from '~/composables/useOrg'
 useHead({ title: 'top' })
 
-const accessibleOrgs: AccessibleOrg[] | null =
-  await useOrg().getAccessibleOrgs()
-const orgInfo: OrgInfo | null =
-  accessibleOrgs != null
-    ? await useOrg().getOrgInfo(accessibleOrgs[0].id)
-    : null
+const accessibleOrgs: Ref<AccessibleOrg[]> = ref(
+  await useOrg()
+    .getAccessibleOrgs()
+    .catch((e) => {
+      console.error(e)
+      return []
+    })
+)
+const orgInfo: Ref<OrgInfo | null> = ref(
+  await useOrg()
+    .getCurrentOrg()
+    .catch((e) => {
+      console.error(e)
+      return null
+    })
+)
+const switchOrg = async (orgId: string) => {
+  await useOrg().setCurrentOrg(orgId)
+  orgInfo.value = await useOrg().getCurrentOrg()
+}
 </script>
 <template>
   <main class="main-content-wrapper">
-    <div v-if="!accessibleOrgs">
+    <div v-if="accessibleOrgs.length === 0">
       <p class="mx-auto w-fit mt-4 xl:ml-8">
         アクセスできる企画団体が存在しません
       </p>
@@ -24,6 +38,14 @@ const orgInfo: OrgInfo | null =
       <pre class="util-color-bg-main w-fit p-5 mx-auto mt-4">{{
         'デフォルトの企画団体情報: ' + JSON.stringify(orgInfo, null, '\t')
       }}</pre>
+    </div>
+    <div class="util-color-bg-main w-fit p-5 mx-auto mt-4">
+      <p
+        v-for="org in accessibleOrgs"
+        class="util-color-border border-solid m-2 border-round p-2 border-round-xl hover:text-primary hover:border-primary"
+      >
+        <span @click="switchOrg(org.id)">{{ org.name }}</span>
+      </p>
     </div>
   </main>
 </template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -24,7 +24,7 @@ const switchOrg = async (orgId: string) => {
 }
 </script>
 <template>
-  <main class="main-content-wrapper">
+  <main>
     <div v-if="accessibleOrgs.length === 0">
       <p class="mx-auto w-fit mt-4 xl:ml-8">
         アクセスできる企画団体が存在しません

--- a/stores/orgId.ts
+++ b/stores/orgId.ts
@@ -1,0 +1,25 @@
+// stores/orgId.js
+import { defineStore } from 'pinia'
+
+export const useOrgIdStore = defineStore('orgId', {
+  state: (): { orgId: string } => {
+    return {
+      orgId: localStorage.getItem('orgId') || ''
+    }
+  },
+  actions: {
+    setOrgId(newOrgId: string) {
+      this.orgId = newOrgId
+      localStorage.setItem('orgId', newOrgId)
+    },
+    clearOrgId() {
+      this.orgId = ''
+      localStorage.removeItem('orgId')
+    }
+  },
+  getters: {
+    getOrgId(): string {
+      return this.orgId
+    }
+  }
+})


### PR DESCRIPTION
- **:sparkles: feat: useOrg composables**
- **:sparkles: useOrgsの使用**

**先行PR#64があります**

# PRで実装される機能
- useOrg.ts
  - accesibleOrgs()
  - getOrgInfo()
  - index.vueの一時的な表示

# PRで修正される機能
- enableRouting: true
- default.vueでの getCurrentUser()の呼び出し

# やっていないこと
- 企画団体のSwitchに関してはノータッチです。別PRに分けることにしました。

# 確認して欲しいこと
- Shionくんの環境で上手く表示できるか確認して欲しいです！
![こんな感じ](https://github.com/shion1305/ynufes-mypage-frontend/assets/92842986/2ef1fabd-6d42-4b90-955e-1d4e73331d1d)

