### PR TITLE
issuesのデフォルトのAssigneesの削除

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,9 +2,6 @@ name: 🐛Bug Report
 description: 'Did you spot BIG cockroach running on the street? Try to catch it, freeze it, and then send it to us🐛'
 title: '🐛🔧 '
 labels: ['bug']
-assignees:
-  - shion1305
-  - tomoyahiroe
 body:
   - type: textarea
     id: summary

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,9 +2,6 @@ name: 💡Feature Request
 description: Are you desperate for a new feature? Wanna talk with us to make it real? Request it! Grow the world as you want. ALWAYS great ideas are in your mind. Unleash and let it see the sunlight🌞
 title: '✨⚡️📝🔥🔧 '
 labels: ['suggestion']
-assignees:
-  - shion1305
-  - tomoyahiroe
 body:
   - type: textarea
     id: feature-description

--- a/.github/ISSUE_TEMPLATE/feature_todo.yml
+++ b/.github/ISSUE_TEMPLATE/feature_todo.yml
@@ -2,9 +2,6 @@ name: ✨Feature Implementation
 description: Hey, so you're working on a feature? Feel free to tell your awesome story/progress and you will get a Donut from us just for free🍩
 title: '✨⚡️📝🔥🔧 '
 labels: ['todo']
-assignees:
-  - shion1305
-  - tomoyahiroe
 body:
   - type: textarea
     id: todo-description


### PR DESCRIPTION
- **📝 remove default assignees for issues**

# PRで修正される機能

- デフォルトで担当者が割り振りされるようになっていたが、Projectで管理する際に担当者手動で割り振ってタスク分担したいので削除

# レビューをお願いしたいポイント

これでいいよね?
